### PR TITLE
add: Python 3.11.0 package from Piston

### DIFF
--- a/packages/python/3.11.0/build.sh
+++ b/packages/python/3.11.0/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+PREFIX=$(realpath $(dirname $0))
+
+mkdir -p build
+
+cd build
+
+curl "https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tgz" -o python.tar.gz
+tar xzf python.tar.gz --strip-components=1
+rm python.tar.gz
+
+./configure --prefix "$PREFIX" --with-ensurepip=install
+make -j$(nproc)
+make install -j$(nproc)
+
+cd ..
+
+rm -rf build
+
+bin/pip3 install numpy scipy pandas pycryptodome whoosh bcrypt passlib sympy xxhash base58 cryptography PyNaCl

--- a/packages/python/3.11.0/environment
+++ b/packages/python/3.11.0/environment
@@ -1,0 +1,1 @@
+export PATH=$PWD/bin:$PATH

--- a/packages/python/3.11.0/metadata.json
+++ b/packages/python/3.11.0/metadata.json
@@ -1,0 +1,5 @@
+{
+    "language": "python",
+    "version": "3.11.0",
+    "aliases": ["py", "py3", "python3", "python3.11"]
+}

--- a/packages/python/3.11.0/run
+++ b/packages/python/3.11.0/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3.11 "$@"

--- a/packages/python/3.11.0/test.py
+++ b/packages/python/3.11.0/test.py
@@ -1,0 +1,7 @@
+working = True
+
+match working:
+    case True:
+        print("OK")
+    case False:
+        print()


### PR DESCRIPTION
- Copy Python 3.11.0 package structure from Piston
- Includes build.sh, metadata.json, run script, and test.py
- Should trigger package-pr validation workflow
- Test package validation and build process